### PR TITLE
Maintenance docs & client_max_body_size setting for Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,41 @@ vagrant up
 
 Wait a while... then, you can browse http://127.0.0.1:8888/
 
-If you want to load your own db/version of DHIS 2:
+
+## Maintenance
+
+It is required to SSH into the Virtual Machine by running:
 
 ```bash
 vagrant ssh
+```
+
+### Clear out DHIS2 database
+
+```bash
+sudo -i
+systemctl tomcat stop
+dropdb -U dhis dhis2
+createdb -U postgres -O dhis dhis2
+logout
+```
+
+### Check DHIS2 logs
+
+```bash
+tail -f /opt/dhis2/logs/dhis.log
+```
+
+### Load different DHIS2 version
+
+```bash
+sudo -i
+systemctl tomcat stop
+cd /var/lib/tomcat/webapps
+rm -f ROOT.war
+rm -rf ROOT/
+wget -O ROOT.war https://url/to/DHIS2.war
+systemctl tomcat start
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ vagrant ssh
 
 ```bash
 sudo -i
-systemctl tomcat stop
+systemctl stop tomcat
 dropdb -U dhis dhis2
 createdb -U postgres -O dhis dhis2
 logout
@@ -45,12 +45,12 @@ tail -f /opt/dhis2/logs/dhis.log
 
 ```bash
 sudo -i
-systemctl tomcat stop
+systemctl stop tomcat
 cd /var/lib/tomcat/webapps
 rm -f ROOT.war
 rm -rf ROOT/
 wget -O ROOT.war https://url/to/DHIS2.war
-systemctl tomcat start
+systemctl start tomcat
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ It is required to SSH into the Virtual Machine by running:
 
 ```bash
 vagrant ssh
+sudo -i
 ```
 
 ### Clear out DHIS2 database
 
 ```bash
-sudo -i
 service tomcat stop
 psql -U dhis -d dhis2 -c "drop schema public cascade; create schema public;"
 logout
@@ -53,7 +53,6 @@ tail -f /opt/dhis2/logs/dhis.log
 ### Load different DHIS2 version
 
 ```bash
-sudo -i
 service tomcat stop
 cd /var/lib/tomcat/webapps
 rm -f ROOT.war

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ createdb -U postgres -O dhis dhis2
 logout
 ```
 
+### Load your own DHIS2 database
+
+Put your SQL file into the repository where you cloned it (on your host machine).
+Clear out database as described above.
+Shared files are in the `/vagrant` folder within the guest VM.
+
+```bash
+psql -U dhis -d dhis2 -f /vagrant/file.sql
+```
+
 ### Check DHIS2 logs
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ vagrant ssh
 
 ```bash
 sudo -i
-systemctl stop tomcat
+service tomcat stop
 psql -U dhis -d dhis2 -c "drop schema public cascade; create schema public;"
 logout
 ```
@@ -54,15 +54,16 @@ tail -f /opt/dhis2/logs/dhis.log
 
 ```bash
 sudo -i
-systemctl stop tomcat
+service tomcat stop
 cd /var/lib/tomcat/webapps
 rm -f ROOT.war
 rm -rf ROOT/
 wget -O ROOT.war https://url/to/DHIS2.war
-systemctl start tomcat
+service tomcat start
 ```
 
 alternatively, edit `main.yml` to e.g. `dhis2_version: 2.28`
+and run `vagrant --provision` to re-setup.
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ vagrant ssh
 ```bash
 sudo -i
 systemctl stop tomcat
-dropdb -U dhis dhis2
-createdb -U postgres -O dhis dhis2
+psql -U dhis -d dhis2 -c "drop schema public cascade; create schema public;"
 logout
 ```
 
@@ -62,6 +61,9 @@ rm -rf ROOT/
 wget -O ROOT.war https://url/to/DHIS2.war
 systemctl start tomcat
 ```
+
+alternatively, edit `main.yml` to e.g. `dhis2_version: 2.28`
+
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Install PostgreSQL, Tomcat, Nginx, and DHIS 2.29 on CentOS 7.
 
 # Using
 
-Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant](https://www.vagrantup.com/downloads.html) for your platform. Then, in a terminal, navigate to this directory and run `vagrant up`. After provisioning is complete, DHIS2 will be accessible at [http://localhost:8888](http://localhost:8888).
+Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant](https://www.vagrantup.com/downloads.html) for your platform. Then, in a terminal, navigate to this directory and run `vagrant up`. After provisioning is complete, DHIS2 will be accessible at [http://localhost:8080](http://localhost:8080).
 
 ## tl;dr
 
@@ -14,7 +14,7 @@ cd dhis2-centos
 vagrant up
 ```
 
-Wait a while... then, you can browse http://127.0.0.1:8888/
+Wait a while... then, you can browse http://127.0.0.1:8080
 
 
 ## Maintenance

--- a/main.yml
+++ b/main.yml
@@ -215,6 +215,13 @@
       - name: "Nginx: Configure proxy to Tomcat"
         block:
 
+        - name: "Nginx: client_max_body_size 32m"
+          lineinfile:
+            path: /etc/nginx/nginx.conf
+            insertafter: '^[^#]\s+access_log\s+/var/log/nginx/access.log\s+main;\s+'
+            line: '    client_max_body_size 32m;'
+            validate: nginx -c %s -t
+            
         - name: "Nginx: proxy_pass"
           lineinfile:
             path: /etc/nginx/nginx.conf


### PR DESCRIPTION
Reason: Couldn't upload a 1.1MB file for metadata import