### PR TITLE
Updated postgis version

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -52,7 +52,7 @@
 
       - name: "PostgreSQL: Install PostGIS"
         yum:
-          name: postgis2_11
+          name: postgis25_11
           state: present
 
       - name: "PostgreSQL: Enable to start on boot"


### PR DESCRIPTION
Postgis install was failing 

```
ASK [PostgreSQL: Check database 'dhis2' value 'search_path'] ******************
fatal: [default]: FAILED! => {"changed": false, "cmd": "psql  --username=\"postgres\"  --tuples-only  --no-align  --command=\"SELECT rs.setconfig FROM pg_db_role_setting rs LEFT JOIN pg_roles r ON r.oid = rs.setrole LEFT JOIN pg_database d ON d.oid = rs.setdatabase WHERE r.rolname = 'dhis' OR d.datname = 'dhis2';\" | grep -q -E '(=|,\\s*)postgis(\"|,)'\n", "delta": "0:00:00.013621", "end": "2019-06-04 19:34:22.332912", "msg": "non-zero return code", "rc": 1, "start": "2019-06-04 19:34:22.319291", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
...ignoring
```

`yum install postgis25_10` fixed it so I add this to the playbook.